### PR TITLE
chore(docs) refresh all links some other overdue updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2003-2021 Kepler Project, Matthew Wild.
+Copyright (C) 2003-2007 The Kepler Project, 2013-2022 Matthew Wild
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -3,73 +3,24 @@ LuaExpat
 
 [![Unix build](https://img.shields.io/github/workflow/status/lunarmodules/luaexpat/Unix%20build?label=Unix%20build&logo=linux)](https://github.com/lunarmodules/luaexpat/actions/workflows/unix_build.yml)
 [![Luacheck](https://github.com/lunarmodules/luaexpat/workflows/Luacheck/badge.svg)](https://github.com/lunarmodules/luaexpat/actions/workflows/luacheck.yml)
+[![License](https://img.shields.io/badge/license-MIT-success)](https://lunarmodules.github.io/luaexpat/license.html)
 
-Overview
+# Overview
 
 LuaExpat is a SAX XML parser based on the Expat library. LuaExpat is free
 software and uses the same license as Lua 5.1.
 
-Status
 
-Current version is UNRELEASED. It is designed to work with all versions of
-Lua between 5.1 and 5.4. It has been tested on Linux with Expat 2.2.5.
+## Download
 
-Download
+LuaExpat source can be downloaded from the [github releases](https://github.com/lunarmodules/luaexpat/releases)
+or from [LuaRocks](https://luarocks.org/search?q=luaexpat).
 
-LuaExpat source can be downloaded from its project page.
+## History
 
-History
+For version history please [see the documentation](https://lunarmodules.github.io/luaexpat/index.html#history)
 
-Version 1.4.0 [23/Apr/2021]
+## License
 
-        * Improved Lua version support (5.1 - 5.4)
-        * Fix memory leak when callbacks reference a parser object
-        * Expose Expat library version (lxp._EXPAT_VERSION)
+[MIT license](https://lunarmodules.github.io/luaexpat/license.html)
 
-Version 1.3.0 [04/Apr/2014]
-
-        * Lua 5.2 support (thanks Tomás Guisasola Gorham)
-        * support for the XmlDecl handler
-        * add parser:getcurrentbytecount() (XML_GetCurrentByteCount)
-        * ability to disable CharacterData merging
-        * Makefile improvements (thanks Vadim Misbakh-Soloviov)
-
-Version 1.2.0 [02/Jun/2011]
-
-        * support for the StartDoctypeDecl handler
-        * add parser:stop() to abort parsing inside a callback
-
-Version 1.1.0 [05/Jun/2006]
-
-        * adapted to work on both Lua 5.0 and Lua 5.1
-        * updated to Expat 2.0.0
-
-Version 1.0.2 [23/Mar/2006]
-
-        * minor bugfix, lom correct module name is lxp.lom
-
-Version 1.0.1 [06/Jun/2005]
-
-        * minor changes for compatibility with Expat version 1.95.8
-
-Version 1.0 [2/Dec/2004]
-Version 1.0 Beta [4/Apr/2004]
-Version 1.0 Alpha [10/Dec/2003]
-
-References
-
-LuaExpat uses the Expat library. For details on the C API please refer to the article "Using Expat".
-LuaExpat implements the SAX API.
-
-Credits
-
-Version 1.0 was designed by Roberto Ierusalimschy, André Carregal and Tomás Guisasola
-as part of the Kepler Project which holds its copyright. The implementation was coded
-by Roberto Ierusalimschy, based on a previous design by Jay Carlson.
-
-LuaExpat development was sponsored by Fábrica Digital and FINEP.
-
-Contact
-
-For more information please contact us (info at keplerproject dot org). Comments are welcome!
-You can also reach other Kepler developers and users on the Kepler Project mailing list.

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -11,7 +11,7 @@
 <div id="container">
 
 <div id="product">
-	<div id="product_logo"><a href="http://www.keplerproject.org">
+	<div id="product_logo"><a href="https://github.com/lunarmodules/luaexpat">
 		<img alt="LuaExpat logo" src="luaexpat.png"/>
 	</a></div>
 	<div id="product_name"><big><strong>LuaExpat</strong></big></div>
@@ -31,7 +31,6 @@
 				<li><a href="index.html#history">History</a></li>
 				<li><a href="index.html#references">References</a></li>
 				<li><a href="index.html#credits">Credits</a></li>
-				<li><a href="index.html#contact">Contact</a></li>
 			</ul>
 		</li>
 		<li><a href="manual.html">Manual</a>
@@ -44,10 +43,11 @@
 		</li>
 		<li><strong>Examples</strong></li>
 		<li><a href="lom.html">Lua Object Model</a></li>
-		<li><a href="http://luaforge.net/projects/luaexpat/">Project</a>
+		<li><a href="https://github.com/lunarmodules/luaexpat">Project</a>
 			<ul>
-				<li><a href="http://luaforge.net/tracker/?group_id=13">Bug Tracker</a></li>
-				<li><a href="http://luaforge.net/scm/?group_id=13">CVS</a></li>
+				<li><a href="https://github.com/lunarmodules/luaexpat/issues">Bug Tracker</a></li>
+				<li><a href="https://github.com/lunarmodules/luaexpat">Source code</a></li>
+				<li><a href="https://lunarmodules.github.io/luaexpat/">Documentation</a></li>
 			</ul>
 		</li>
 		<li><a href="license.html">License</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@
 <div id="container">
 
 <div id="product">
-	<div id="product_logo"><a href="http://www.keplerproject.org">
+	<div id="product_logo"><a href="https://github.com/lunarmodules/luaexpat">
 		<img alt="LuaExpat logo" src="luaexpat.png"/>
 	</a></div>
 	<div id="product_name"><big><strong>LuaExpat</strong></big></div>
@@ -31,7 +31,6 @@
 				<li><a href="index.html#history">History</a></li>
 				<li><a href="index.html#references">References</a></li>
 				<li><a href="index.html#credits">Credits</a></li>
-				<li><a href="index.html#contact">Contact</a></li>
 			</ul>
 		</li>
 		<li><a href="manual.html">Manual</a>
@@ -44,10 +43,11 @@
 		</li>
 		<li><a href="examples.html">Examples</a></li>
 		<li><a href="lom.html">Lua Object Model</a></li>
-		<li><a href="http://luaforge.net/projects/luaexpat/">Project</a>
+		<li><a href="https://github.com/lunarmodules/luaexpat">Project</a>
 			<ul>
-				<li><a href="http://luaforge.net/tracker/?group_id=13">Bug Tracker</a></li>
-				<li><a href="http://luaforge.net/scm/?group_id=13">CVS</a></li>
+				<li><a href="https://github.com/lunarmodules/luaexpat/issues">Bug Tracker</a></li>
+				<li><a href="https://github.com/lunarmodules/luaexpat">Source code</a></li>
+				<li><a href="https://lunarmodules.github.io/luaexpat/">Documentation</a></li>
 			</ul>
 		</li>
 		<li><a href="license.html">License</a></li>
@@ -59,9 +59,9 @@
 <h2><a name="overview"></a>Overview</h2>
 
 <p>LuaExpat is a <a href="http://www.saxproject.org/">SAX</a> XML parser based on the
-<a href="http://www.libexpat.org/">Expat</a> library.</p>
+<a href="https://www.libexpat.org/">Expat</a> library.</p>
 
-<p>LuaExpat is free software and uses the same <a href="license.html">license</a>
+<p>LuaExpat is free software and uses the same <a href="license.html">MIT license</a>
 as Lua 5.1.</p>
 
 <h2><a name="status"></a>Status</h2>
@@ -70,8 +70,6 @@ as Lua 5.1.</p>
 Linux, Windows (XP) and MacOS X with Expat 2.1.0.</p>
 
 <h2><a name="download"></a>Download</h2>
-
-<p>The latest LuaExpat release is 1.3.0.</p>
 
 <ul>
 	<li><a href="https://matthewwild.co.uk/projects/luaexpat/luaexpat-1.3.0.tar.gz">luaexpat-1.3.0.tar.gz</a> <a href="https://matthewwild.co.uk/projects/luaexpat/luaexpat-1.3.0.tar.gz.asc">(signature)</a></li>
@@ -82,18 +80,37 @@ Linux, Windows (XP) and MacOS X with Expat 2.1.0.</p>
 <a href="http://files.luaforge.net/releases/luaexpat/LuaExpat">LuaForge</a>
 page.</p>
 
-<p>Binaries for Windows are bundled with the <a href="https://code.google.com/p/luaforwindows/">Lua
+<p>Binaries for Windows are bundled with the <a href="https://github.com/rjpcomputing/luaforwindows">Lua
 for Windows</a> project.</p>
 
-<p>LuaExpat is also available from the main <a href="http://luarocks.org/">LuaRocks</a> repository, as 'luaexpat'.</p>
+<p>LuaExpat is also available from the main <a href="https://luarocks.org/">LuaRocks</a> repository, as 'luaexpat'.</p>
 
 <h2><a name="history"></a>History</h2>
 
 <dl class="history">
+	<dt><strong>Version 1.4.0</strong> [unreleased]</dt>
+	<dd>
+		<ul>
+			<li>Improved Lua version support (5.1 - 5.4)</li>
+			<li>Fix memory leak when callbacks reference a parser object</li>
+			<li>Expose Expat library version (lxp._EXPAT_VERSION)</li>
+			<li>Added 'lxp.totable' module (thanks Tom&aacute;s Guisasola Gorham)</li>
+		</ul>
+	</dd>
+
+	<dt><strong>Version 1.3.2 and Version 1.3.3</strong></dt>
+	<dd>
+		<ul>
+			<li>These versions were from a different fork by Tom&aacute;s Guisasola Gorham</li>
+			<li>Both these versions are available from <a href="https://luarocks.org/search?q=luaexpat">LuaRocks</a></li>
+			<li>The work done there has been integrated in the 1.4.0 version</li>
+		</ul>
+	</dd>
+
 	<dt><strong>Version 1.3.0</strong> [02/Apr/2014]</dt>
 	<dd>
 		<ul>
-			<li>Lua 5.2 support (thanks Tomás Guisasola Gorham)</li>
+			<li>Lua 5.2 support (thanks Tom&aacute;s Guisasola Gorham)</li>
 			<li>support for the XmlDecl handler</li>
 			<li>add parser:getcurrentbytecount() (XML_GetCurrentByteCount)</li>
 			<li>ability to disable CharacterData merging</li>
@@ -118,7 +135,7 @@ for Windows</a> project.</p>
 		</ul>
 	</dd>
 
-	<dt><strong><a href="http://www.keplerproject.org/luaexpat/1.0">Version 1.0.2</a></strong> [23/Mar/2006]</dt>
+	<dt><strong>Version 1.0.2</strong> [23/Mar/2006]</dt>
 	<dd>
 		<ul>
 			<li>minor bugfix, <code>lom</code> correct module name is <code>lxp.lom</code></li>
@@ -145,9 +162,9 @@ for Windows</a> project.</p>
 <h2><a name="references"></a>References</h2>
 
 <p>LuaExpat uses the
-<a href="http://www.libexpat.org/">Expat</a> library.
+<a href="https://www.libexpat.org/">Expat</a> library.
 For details on the C API please refer to the article
-<a href="http://www.xml.com/pub/a/1999/09/expat/index.html?page=1">"Using Expat"</a>.</p>
+<a href="https://www.xml.com/pub/a/1999/09/expat/index.html?page=1">"Using Expat"</a>.</p>
 
 <p>LuaExpat implements the <a href="http://www.saxproject.org/">SAX</a> API.</p>
 
@@ -162,15 +179,6 @@ Roberto Ierusalimschy, based on a previous design by
 <p>LuaExpat development was sponsored by
 <a href="http://www.fabricadigital.com.br">F&aacute;brica Digital</a> and
 FINEP.</p>
-
-<h2><a name="contact"></a>Contact</h2>
-
-<p>For more information please
-<a href="mailto:info-NO-SPAM-THANKS@keplerproject.org">contact us</a>.
-Comments are welcome!</p>
-
-<p>You can also reach other Kepler developers and users on the Kepler Project
-<a href="http://luaforge.net/mail/?group_id=104">mailing list</a>.</p>
 
 </div> <!-- id="content" -->
 

--- a/docs/license.html
+++ b/docs/license.html
@@ -11,7 +11,7 @@
 <div id="container">
 
 <div id="product">
-	<div id="product_logo"><a href="http://www.keplerproject.org">
+	<div id="product_logo"><a href="https://github.com/lunarmodules/luaexpat">
 		<img alt="LuaExpat logo" src="luaexpat.png"/>
 	</a></div>
 	<div id="product_name"><big><strong>LuaExpat</strong></big></div>
@@ -31,7 +31,6 @@
 				<li><a href="index.html#history">History</a></li>
 				<li><a href="index.html#references">References</a></li>
 				<li><a href="index.html#credits">Credits</a></li>
-				<li><a href="index.html#contact">Contact</a></li>
 			</ul>
 		</li>
 		<li><a href="manual.html">Manual</a>
@@ -44,10 +43,11 @@
 		</li>
 		<li><a href="examples.html">Examples</a></li>
 		<li><a href="lom.html">Lua Object Model</a></li>
-		<li><a href="http://luaforge.net/projects/luaexpat/">Project</a>
+		<li><a href="https://github.com/lunarmodules/luaexpat">Project</a>
 			<ul>
-				<li><a href="http://luaforge.net/tracker/?group_id=13">Bug Tracker</a></li>
-				<li><a href="http://luaforge.net/scm/?group_id=13">CVS</a></li>
+				<li><a href="https://github.com/lunarmodules/luaexpat/issues">Bug Tracker</a></li>
+				<li><a href="https://github.com/lunarmodules/luaexpat">Source code</a></li>
+				<li><a href="https://lunarmodules.github.io/luaexpat/">Documentation</a></li>
 			</ul>
 		</li>
 		<li><strong>License</strong></li>
@@ -62,13 +62,8 @@
 LuaExpat is free software: it can be used for both academic and
 commercial purposes at absolutely no cost. There are no royalties
 or GNU-like "copyleft" restrictions. LuaExpat qualifies as <a href=
-"http://www.opensource.org/docs/definition.html">Open Source</a>
-software. Its licenses are compatible with <a href=
-"http://www.gnu.org/licenses/gpl.html">GPL</a>. LuaExpat is not in
-the public domain and the
-<a href="http://www.keplerproject.org">Kepler Project</a>
-keep its copyright. The legal details are below.
-</p>
+"https://www.opensource.org/docs/definition.html">Open Source</a>
+software.</p>
 
 <p>The spirit of the license is that you are free to use LuaExpat
 for any purpose at no cost without having to ask us. The only
@@ -76,13 +71,14 @@ requirement is that if you do use LuaExpat, then you should give us
 credit by including the appropriate copyright notice somewhere in
 your product or its documentation.</p>
 
-<p>The LuaExpat library is designed and implemented by Roberto
+<p>The original LuaExpat library is designed and implemented by Roberto
 Ierusalimschy. The implementation is not derived from licensed
 software.</p>
 
 <hr/>
-<p>Copyright &copy; 2003-2007 The Kepler Project.
-</p>
+<h2><a href="https://opensource.org/licenses/MIT">MIT license</a></h2>
+
+<p>Copyright &copy; 2003-2007 The Kepler Project, 2013-2022 Matthew Wild.</p>
 
 <p>Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/docs/lom.html
+++ b/docs/lom.html
@@ -11,7 +11,7 @@
 <div id="container">
 
 <div id="product">
-	<div id="product_logo"><a href="http://www.keplerproject.org">
+	<div id="product_logo"><a href="https://github.com/lunarmodules/luaexpat">
 		<img alt="LuaExpat logo" src="luaexpat.png"/>
 	</a></div>
 	<div id="product_name"><big><strong>LuaExpat</strong></big></div>
@@ -31,7 +31,6 @@
 				<li><a href="index.html#history">History</a></li>
 				<li><a href="index.html#references">References</a></li>
 				<li><a href="index.html#credits">Credits</a></li>
-				<li><a href="index.html#contact">Contact</a></li>
 			</ul>
 		</li>
 		<li><a href="manual.html">Manual</a>
@@ -44,12 +43,13 @@
 		</li>
 		<li><a href="examples.html">Examples</a></li>
 		<li><strong>Lua Object Model</strong></li>
-        <li><a href="http://luaforge.net/projects/luaexpat/">Project</a>
-            <ul>
-                <li><a href="http://luaforge.net/tracker/?group_id=13">Bug Tracker</a></li>
-                <li><a href="http://luaforge.net/scm/?group_id=13">CVS</a></li>
-            </ul>
-        </li>
+		<li><a href="https://github.com/lunarmodules/luaexpat">Project</a>
+			<ul>
+				<li><a href="https://github.com/lunarmodules/luaexpat/issues">Bug Tracker</a></li>
+				<li><a href="https://github.com/lunarmodules/luaexpat">Source code</a></li>
+				<li><a href="https://lunarmodules.github.io/luaexpat/">Documentation</a></li>
+			</ul>
+		</li>
 		<li><a href="license.html">License</a></li>
 	</ul>
 </div> <!-- id="navigation" -->

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -11,7 +11,7 @@
 <div id="container">
 
 <div id="product">
-	<div id="product_logo"><a href="http://www.keplerproject.org">
+	<div id="product_logo"><a href="https://github.com/lunarmodules/luaexpat">
 		<img alt="LuaExpat logo" src="luaexpat.png"/>
 	</a></div>
 	<div id="product_name"><big><strong>LuaExpat</strong></big></div>
@@ -31,7 +31,6 @@
 				<li><a href="index.html#history">History</a></li>
 				<li><a href="index.html#references">References</a></li>
 				<li><a href="index.html#credits">Credits</a></li>
-				<li><a href="index.html#contact">Contact</a></li>
 			</ul>
 		</li>
 		<li><strong>Manual</strong>
@@ -44,10 +43,11 @@
 		</li>
 		<li><a href="examples.html">Examples</a></li>
 		<li><a href="lom.html">Lua Object Model</a></li>
-		<li><a href="http://luaforge.net/projects/luaexpat/">Project</a>
+		<li><a href="https://github.com/lunarmodules/luaexpat">Project</a>
 			<ul>
-				<li><a href="http://luaforge.net/tracker/?group_id=13">Bug Tracker</a></li>
-				<li><a href="http://luaforge.net/scm/?group_id=13">CVS</a></li>
+				<li><a href="https://github.com/lunarmodules/luaexpat/issues">Bug Tracker</a></li>
+				<li><a href="https://github.com/lunarmodules/luaexpat">Source code</a></li>
+				<li><a href="https://lunarmodules.github.io/luaexpat/">Documentation</a></li>
 			</ul>
 		</li>
 		<li><a href="license.html">License</a></li>
@@ -59,7 +59,7 @@
 <h2><a name="introduction"></a>Introduction</h2>
 
 <p>LuaExpat is a <a href="http://www.saxproject.org/">SAX</a> XML
-parser based on the <a href="http://www.libexpat.org/">Expat</a> library.
+parser based on the <a href="https://www.libexpat.org/">Expat</a> library.
 SAX is the <em>Simple API for XML</em> and allows programs to:
 </p>
 
@@ -86,18 +86,16 @@ implements the <a href="lom.html">Lua Object Model</a>.</p>
 <h2><a name="building"></a>Building</h2>
 
 <p>
-LuaExpat could be built to Lua 5.1 or to Lua 5.2.
-In both cases,
-the language library and headers files for the desired version
+LuaExpat could be built for Lua 5.1 to 5.4.
+The language library and headers files for the desired version
 must be installed properly.
 LuaExpat also depends on Expat 2.0.0+ which should also be installed.
 </p>
+
+<p>The simplest way of building and installing LuaExpat is through LuaRocks.</p>
+
 <p>
-LuaExpat offers a Makefile and a separate configuration file,
-<code>config</code>,
-which should be edited to suit the particularities of the target platform
-before running
-<code>make</code>.
+LuaExpat also offers a Makefile.
 The file has some definitions like paths to the external libraries,
 compiler options and the like.
 One important definition is the version of Lua language,
@@ -107,16 +105,11 @@ which is not obtained from the installed software.
 
 <h2><a name="installation"></a>Installation</h2>
 
-<p>The compiled binary file should be copied to a directory in your
+<p> installation can be done using LuaRocks or <code>make install</code>.</p>
+
+<p>Manually, the compiled binary file should be copied to a directory in your
 <a href="http://www.lua.org/manual/5.1/manual.html#pdf-package.cpath">C path</a>.
-Lua 5.0 users should also install
-<a href="http://www.keplerproject.org/compat">Compat-5.1</a>.</p>
-
-<p>Windows users can use the binary version of LuaExpat (<code>lxp.dll</code>, compatible with
-<a href="http://luabinaries.luaforge.net">LuaBinaries</a>) available at
-<a href="http://luaforge.net/projects/luaexpat/files">LuaForge</a>.</p>
-
-<p>The file <code>lom.lua</code> should be copied to a directory in your
+The Lua files <code>./src/lxp/*.lua</code> should be copied to a directory in your
 <a href="http://www.lua.org/manual/5.1/manual.html#pdf-package.path">Lua path</a>.</p>
 
 <h2><a name="parser"></a>Parser objects</h2>

--- a/src/lxplib.c
+++ b/src/lxplib.c
@@ -579,7 +579,7 @@ static const struct luaL_Reg lxp_funcs[] = {
 */
 static void set_info (lua_State *L) {
   lua_pushliteral (L, "_COPYRIGHT");
-  lua_pushliteral (L, "Copyright (C) 2003-2021 Kepler Project, Matthew Wild");
+  lua_pushliteral (L, "Copyright (C) 2003-2007 The Kepler Project, 2013-2022 Matthew Wild");
   lua_settable (L, -3);
   lua_pushliteral (L, "_DESCRIPTION");
   lua_pushliteral (L, "LuaExpat is a SAX XML parser based on the Expat library");


### PR DESCRIPTION
Most updates are minor. The important one is the copyright.

I updated it to `Copyright (C) 2003-2007 The Kepler Project, 2013-2022 Matthew Wild`, because;

* 2003-2007 was the one referencing Kepler, and since this is the weird one since Kepler isn't a legal entity, I kept it at 2007.
* 2013 was Matthews first release, up till now; 2022

Since I'm not mentioning Tomas here... Maybe the intermediate period was by Tomas? please advise @tomasguisasola @mwild1 