### PR TITLE
feat(lxp) return parser on methods without results

### DIFF
--- a/docs/manual.html
+++ b/docs/manual.html
@@ -159,7 +159,7 @@ document will be closed and an error will be returned;</p>
 	<dt><strong>parser:close()</strong></dt>
 	<dd>Closes the parser, freeing all memory used by it. A call to
 	parser:close() without a previous call to parser:parse() could
-	result in an error.</dd>
+	result in an error. Returns the parser object on success.</dd>
 
 	<dt><strong>parser:getbase()</strong></dt>
 	<dd>Returns the base for resolving relative URIs.</dd>
@@ -172,11 +172,17 @@ document will be closed and an error will be returned;</p>
 	part (or perhaps all) of the document. When called without
 	arguments the document is closed (but the parser still has to be
 	closed).<br/>
-	The function returns a non nil value when the parser has been
-	succesfull, and when the parser finds an error it returns five
-	results: nil, <em>msg</em>, <em>line</em>, <em>col</em>, and
+	The function returns the parser object when the parser has been
+	succesfull. If the parser finds an error it returns five
+	results: <em>nil</em>, <em>msg</em>, <em>line</em>, <em>col</em>, and
 	<em>pos</em>, which are the error message, the line number,
-	column number and absolute position of the error in the XML document.</dd>
+	column number and absolute position of the error in the XML document.
+<pre class="example">
+local cb = {}    -- table with callbacks
+local doc = "&lt;root&gt;xml doc&lt;/root&gt;"
+lxp.new(cb):setencoding("UTF-8"):parse(doc):parse():close()
+</pre>
+	</dd>
 
 	<dt><strong>parser:pos()</strong></dt>
 	<dd>Returns three results: the current parsing line, column, and
@@ -186,16 +192,16 @@ document will be closed and an error will be returned;</p>
 	<dd>Return the number of bytes of input corresponding to the current
 	event. This function can only be called inside a handler, in other
 	contexts it will return 0. Do not use inside a CharacterData handler
-	unless CharacterData merging has been disabled (see lxp.new).</dd>
+	unless CharacterData merging has been disabled (see <em>lxp.new</em>).</dd>
 
 	<dt><strong>parser:setbase(base)</strong></dt>
 	<dd>Sets the <em>base</em> to be used for resolving relative URIs in
-	system identifiers.</dd>
+	system identifiers. Returns the parser object on success.</dd>
 
 	<dt><strong>parser:setencoding(encoding)</strong></dt>
 	<dd>Set the encoding to be used by the parser. There are four
 	built-in encodings, passed as strings: "US-ASCII",
-	"UTF-8", "UTF-16", and "ISO-8859-1".</dd>
+	"UTF-8", "UTF-16", and "ISO-8859-1". Returns the parser object on success.</dd>
 
 	<dt><strong>parser:stop()</strong></dt>
 	<dd>Abort the parser and prevent it from parsing any further

--- a/spec/01-lxp_spec.lua
+++ b/spec/01-lxp_spec.lua
@@ -94,6 +94,13 @@ describe("lxp:", function()
 		end)
 
 
+		it("setbase, setencoding, close, and parse return parser upon success", function()
+			assert.has.no.error(function()
+				lxp.new({}):setbase("/base"):setencoding("ISO-8859-1"):parse("<root/>"):parse():close():close()
+			end)
+		end)
+
+
 		-- test based on https://github.com/tomasguisasola/luaexpat/issues/2
 		it("reloads module if dropped", function()
 			package.loaded.lxp = nil

--- a/src/lxplib.c
+++ b/src/lxplib.c
@@ -449,7 +449,8 @@ static int setbase (lua_State *L) {
   lxp_userdata *xpu = checkparser(L, 1);
   if (XML_SetBase(xpu->parser, luaL_checkstring(L, 2)) == 0)
     luaL_error(L, "no memory to store base");
-  return 0;
+  lua_settop(L, 1);
+  return 1;
 }
 
 
@@ -484,7 +485,7 @@ static int parse_aux (lua_State *L, lxp_userdata *xpu, const char *s,
   }
   if (s == NULL) xpu->state = XPSfinished;
   if (status) {
-    lua_pushboolean(L, 1);
+    lua_settop(L, 1);  /* return parser userdata on success */
     return 1;
   }
   else { /* error */
@@ -503,7 +504,7 @@ static int lxp_parse (lua_State *L) {
       lua_pushliteral(L, "cannot parse - document is finished");
       return 2;
     } else {
-      lua_pushboolean(L, 1);
+      lua_settop(L, 1);
       return 1;
     }
   }
@@ -520,7 +521,8 @@ static int lxp_close (lua_State *L) {
   lxpclose(L, xpu);
   if (status > 1) luaL_error(L, "error closing parser: %s",
                                 lua_tostring(L, -status+1));
-  return 0;
+  lua_settop(L, 1);
+  return 1;
 }
 
 
@@ -539,7 +541,8 @@ static int lxp_setencoding (lua_State *L) {
   const char *encoding = luaL_checkstring(L, 2);
   luaL_argcheck(L, xpu->state == XPSpre, 1, "invalid parser state");
   XML_SetEncoding(xpu->parser, encoding);
-  return 0;
+  lua_settop(L, 1);
+  return 1;
 }
 
 static int lxp_stop (lua_State *L) {


### PR DESCRIPTION
By returning the parser instead of 'true', calls can be easily chained.

See the added test case for an example