### PR TITLE
fix(lxp) XmlDecl can also return nil for 'standalone'

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -101,6 +101,7 @@ for Windows</a> project.</p>
 			<li>Expose Expat library version (lxp._EXPAT_VERSION)</li>
 			<li>Added 'lxp.totable' module (thanks Tom&aacute;s Guisasola Gorham)</li>
 			<li>Fix integers being returned as floats on Lua 5.3+ (thanks Kim Alvefur)</li>
+			<li>Fix XmlDecl callback can also return 'nil' for 'standalone'</li>
 			<li>Many documentation updates</li>
 			<li>More tests and new test setup; Busted, LuaCheck, Github actions</li>
 			<li>Improved finishing, multiple nil-calls no longer throw errors</li>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -385,7 +385,7 @@ for more than one parser for example.</p>
 	<dd>Called when the <em>parser</em> encounters an XML document declaration (these are
 	optional, and valid only at the start of the document). The callback receives
 	the declared XML <em>version</em> and document <em>encoding</em> as strings, and
-	<em>standalone</em> as a boolean.</dd>
+	<em>standalone</em> as a boolean (or <em>nil</em> if it was not specified).</dd>
 </dl>
 
 <h4><a name="separator"></a>The separator character</h4>

--- a/spec/01-lxp_spec.lua
+++ b/spec/01-lxp_spec.lua
@@ -180,6 +180,27 @@ describe("lxp:", function()
 		end)
 
 
+		it("handles XML declaration", function()
+			local p = test_parser { "XmlDecl" }
+			assert(p:parse('<?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?>'))
+			assert.same({
+				{ "XmlDecl", "1.0", "ISO-8859-1", true },
+			}, cbdata)
+
+			local p = test_parser { "XmlDecl" }
+			assert(p:parse('<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>'))
+			assert.same({
+				{ "XmlDecl", "1.0", "ISO-8859-1", false },
+			}, cbdata)
+
+			local p = test_parser { "XmlDecl" }
+			assert(p:parse('<?xml version="1.0" encoding="ISO-8859-1"?>'))
+			assert.same({
+				{ "XmlDecl", "1.0", "ISO-8859-1", nil },
+			}, cbdata)
+		end)
+
+
 		it("handles start/end tags", function()
 			local p = test_parser { "StartElement", "EndElement" }
 			assert(p:parse(preamble))

--- a/src/lxplib.c
+++ b/src/lxplib.c
@@ -343,8 +343,12 @@ static void f_XmlDecl (void *ud, const XML_Char *version,
   if (getHandle(xpu, XmlDeclKey) == 0) return;  /* no handle */
   lua_pushstring(xpu->L, version);
   lua_pushstring(xpu->L, encoding);
-  lua_pushboolean(xpu->L, standalone);
-  docall(xpu, 3, 0);
+  if (standalone >= 0) {
+    lua_pushboolean(xpu->L, standalone);
+    docall(xpu, 3, 0);
+  } else {
+    docall(xpu, 2, 0);
+  }
 }
 /* }====================================================== */
 


### PR DESCRIPTION
nil is returned in case 'standalone' was not specified.