### PR TITLE
fix(threat) line was taken as position

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -90,6 +90,13 @@ for Windows</a> project.</p>
 <h2><a name="history"></a>History</h2>
 
 <dl class="history">
+	<dt><strong>Version x.y.z</strong> [unreleased]</dt>
+	<dd>
+		<ul>
+			<li>Fix bad buffer size calculation in threat parser</li>
+		</ul>
+	</dd>
+
 	<dt><strong>Version 1.4.0</strong> [22/Mar/2022]</dt>
 	<dd>
 		<ul>

--- a/src/lxp/threat.lua
+++ b/src/lxp/threat.lua
@@ -143,8 +143,11 @@ function threat.new(callbacks, separator, merge_character_data)
 			if threat_error_data then
 				return nil, threat_error_data[1], threat_error_data[2], threat_error_data[3], threat_error_data[4]
 			end
-			if checks.buffer and size - parser:pos() > checks.buffer then
-				return nil, "unparsed buffer too large"
+			if checks.buffer then
+				local _, _, pos = parser:pos()
+				if size - pos > checks.buffer then
+					return nil, "unparsed buffer too large"
+				end
 			end
 			if a == parser then
 				return p,b,c,d,e


### PR DESCRIPTION
the first result of 'pos()' is the current line, the position is
return result nr 3. This caused the buffer size to be calculated
in a bad way.