### PR TITLE
feat(parser) add Billion Laughs config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode
+
 # Compiled Lua sources
 luac.out
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -101,6 +101,9 @@ for Windows</a> project.</p>
 			included in the exposed API of Expat. This means that LuaExpat will now be compiled
 			using the same options used to compile Expat itself.</li>
 			<li>Add configuration for Billion Laughs Attack prevention</li>
+			<li>Expose Expat compile time constants (lxp._EXPAT_FEATURES), see
+			<a href="https://libexpat.github.io/doc/api/latest/#XML_GetFeatureList">
+			Expat documentation</a>.</li>
 		</ul>
 	</dd>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -72,7 +72,7 @@ as Lua 5.1.</p>
 <h2><a name="status"></a>Status</h2>
 
 <p>Current version is 1.4.1. It was developed for Lua 5.1 to Lua 5.4, and has been tested on
-Linux, Windows (XP) and MacOS X with Expat 2.1.0.</p>
+Linux and MacOS X with Expat 2.4.0+.</p>
 
 <h2><a name="download"></a>Download</h2>
 
@@ -92,7 +92,15 @@ for Windows</a> project.</p>
 	<dt><strong>Version 1.5.0</strong> [unreleased]</dt>
 	<dd>
 		<ul>
-			<li>Added option "allowDTD" to the threat protection parser</li>
+			<li><strong>warning:</strong> this update requires a minimum libExpat
+			version of 2.4.0. Though at the time of writing a minimum version of
+			2.4.6 is recommended <a href="https://www.cvedetails.com/vulnerability-list.php?vendor_id=16735">
+			due to CVE's fixed</a> in the intermediate versions.</li>
+			<li>Added option "allowDTD" to the threat protection parser. This includes adding
+			<code>#include "expat_config.h"</code>, since these functions are conditionally
+			included in the exposed API of Expat. This means that LuaExpat will now be compiled
+			using the same options used to compile Expat itself.</li>
+			<li>Add configuration for Billion Laughs Attack prevention</li>
 		</ul>
 	</dd>
 

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -205,6 +205,18 @@ lxp.new(cb):setencoding("UTF-8"):parse(doc):parse():close()
 	<dd>Sets the <em>base</em> to be used for resolving relative URIs in
 	system identifiers. Returns the parser object on success.</dd>
 
+	<dt><strong>parser:setblamaxamplification(max_amp)</strong></dt>
+	<dd>Sets the <em>maximum amplification</em> (float) to be allowed. This
+	protects against the Billion Laughs Attack. The
+	<em>libexpat</em> default is 100. Returns the parser object on success.<br/>
+	</dd>
+
+	<dt><strong>parser:setblathreshold(threshold)</strong></dt>
+	<dd>Sets the <em>threshold</em> (int, in bytes) after which the protection
+	starts. This protects against the Billion Laughs Attack. The
+	<em>libexpat</em> default is 8 MiB. Returns the parser object on success.<br/>
+	</dd>
+
 	<dt><strong>parser:setencoding(encoding)</strong></dt>
 	<dd>Set the encoding to be used by the parser. There are four
 	built-in encodings, passed as strings: "US-ASCII",

--- a/spec/01-lxp_spec.lua
+++ b/spec/01-lxp_spec.lua
@@ -80,6 +80,8 @@ describe("lxp:", function()
 			assert.is.string(lxp._DESCRIPTION)
 			assert.is.string(lxp._COPYRIGHT)
 			assert.is.string(lxp._EXPAT_VERSION)
+			assert.is.table(lxp._EXPAT_FEATURES)
+			assert.is.number(lxp._EXPAT_FEATURES.XML_CONTEXT_BYTES)
 		end)
 
 

--- a/spec/01-lxp_spec.lua
+++ b/spec/01-lxp_spec.lua
@@ -96,9 +96,16 @@ describe("lxp:", function()
 		end)
 
 
-		it("setbase, setencoding, close, and parse return parser upon success", function()
+		it("setbase, setblamaxamplification, setblathreshold, setencoding, close, and parse return parser upon success", function()
 			assert.has.no.error(function()
-				lxp.new({}):setbase("/base"):setencoding("ISO-8859-1"):parse("<root/>"):parse():close():close()
+				lxp.new({}):setbase("/base"):
+							setblamaxamplification(55.55):
+							setblathreshold(1024*1024):
+							setencoding("ISO-8859-1"):
+							parse("<root/>"):
+							parse():
+							close():
+							close()
 			end)
 		end)
 

--- a/src/lxp/threat.lua
+++ b/src/lxp/threat.lua
@@ -122,6 +122,14 @@ function threat.new(callbacks, separator, merge_character_data)
 		local ok, err = parser:setbase(base)
 		return ok == parser and p or ok, err
 	end
+	function p:setblamaxamplification(amp)
+		local ok, err = parser:setblamaxamplification(amp)
+		return ok == parser and p or ok, err
+	end
+	function p:setblathreshold(threshold)
+		local ok, err = parser:setblathreshold(threshold)
+		return ok == parser and p or ok, err
+	end
 	function p:setencoding(encoding)
 		local ok, err = parser:setencoding(encoding)
 		return ok == parser and p or ok, err

--- a/src/lxplib.c
+++ b/src/lxplib.c
@@ -813,6 +813,17 @@ static void set_info (lua_State *L) {
   lua_pushliteral (L, "_EXPAT_VERSION");
   lua_pushstring (L, XML_ExpatVersion());
   lua_settable (L, -3);
+  /* create feature list */
+  lua_pushliteral (L, "_EXPAT_FEATURES");
+  lua_newtable (L);
+
+  const XML_Feature *features;
+  for (features = XML_GetFeatureList (); features->name != NULL; features++) {
+    lua_pushstring (L, features->name);
+    lua_pushinteger (L, features->value);
+    lua_settable (L, -3);
+  }
+  lua_settable (L, -3);
 }
 
 int luaopen_lxp (lua_State *L) {

--- a/src/lxplib.c
+++ b/src/lxplib.c
@@ -9,7 +9,11 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "expat_config.h"
 #include "expat.h"
+#if (XML_MAJOR_VERSION == 2 && XML_MINOR_VERSION < 4) || (XML_MAJOR_VERSION < 2)
+#error Expat 2.4 or newer is required
+#endif
 
 #include "lua.h"
 #include "lauxlib.h"
@@ -712,6 +716,7 @@ static int lxp_setreturnnstriplet (lua_State *L) {
   return 1;
 }
 
+
 static int lxp_setencoding (lua_State *L) {
   lxp_userdata *xpu = checkparser(L, 1);
   const char *encoding = luaL_checkstring(L, 2);
@@ -721,11 +726,40 @@ static int lxp_setencoding (lua_State *L) {
   return 1;
 }
 
+
 static int lxp_stop (lua_State *L) {
   lxp_userdata *xpu = checkparser(L, 1);
   lua_pushboolean(L, XML_StopParser(xpu->parser, XML_FALSE) == XML_STATUS_OK);
   return 1;
 }
+
+
+/* Billion Laughs Attack mitigation from Expat 2.4.0+ */
+#ifdef XML_DTD
+static int lxp_bla_maximum_amplification (lua_State *L) {
+  lxp_userdata *xpu = checkparser(L, 1);
+  if (! XML_SetBillionLaughsAttackProtectionMaximumAmplification(xpu->parser, luaL_checknumber(L, 2))) {
+    lua_pushnil(L);
+    lua_pushliteral(L, "failed to set BLA maximum amplification");
+    return 2;
+  }
+  lua_settop(L, 1);
+  return 1;
+}
+
+
+static int lxp_bla_activation_threshold (lua_State *L) {
+  lxp_userdata *xpu = checkparser(L, 1);
+  if (! XML_SetBillionLaughsAttackProtectionActivationThreshold(xpu->parser, luaL_checkinteger(L, 2))) {
+    lua_pushnil(L);
+    lua_pushliteral(L, "failed to set BLA activation threshold");
+    return 2;
+  }
+  lua_settop(L, 1);
+  return 1;
+}
+#endif
+
 
 #if !defined LUA_VERSION_NUM
 /* Lua 5.0 */
@@ -750,6 +784,10 @@ static const struct luaL_Reg lxp_meths[] = {
   {"setbase", setbase},
   {"returnnstriplet", lxp_setreturnnstriplet},
   {"stop", lxp_stop},
+#ifdef XML_DTD
+  {"setblamaxamplification", lxp_bla_maximum_amplification},
+  {"setblathreshold", lxp_bla_activation_threshold},
+#endif
   {NULL, NULL}
 };
 


### PR DESCRIPTION
Adds 2 methods to configure protection against the Billion Laughs Attack; amplification and threshold.

This is only available on LibExpat 2.4.0+, so it will fail to compile with any older version. Though I do find this problematic, I'm still in favor of it due to all recent CVE's on Expat that have been fixed in versions up to 2.4.6. So forcing updates seems like a sane/safe thing to do.

It also adds a new constant; `lxp._EXPAT_FEATURES`, which is a table with compile time defaults for libExpat. I chopose NOT to document this new constant (other than the changelog) because other constants also haven't been documented.