### PR TITLE
chore(lxp) use $(INSTALL_DATA) for *.lua

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ src/$(LIBNAME):
 
 install:
 	$(INSTALL_PROGRAM) -D src/$(LIBNAME) $(DESTDIR)$(LUA_CDIR)/$(LIBNAME)
-	$(INSTALL_PROGRAM) -D src/$T/lom.lua $(DESTDIR)$(LUA_LDIR)/$T/lom.lua
-	$(INSTALL_PROGRAM) -D src/$T/totable.lua $(DESTDIR)$(LUA_LDIR)/$T/totable.lua
-	$(INSTALL_PROGRAM) -D src/$T/threat.lua $(DESTDIR)$(LUA_LDIR)/$T/threat.lua
+	$(INSTALL_DATA) -D src/$T/lom.lua $(DESTDIR)$(LUA_LDIR)/$T/lom.lua
+	$(INSTALL_DATA) -D src/$T/totable.lua $(DESTDIR)$(LUA_LDIR)/$T/totable.lua
+	$(INSTALL_DATA) -D src/$T/threat.lua $(DESTDIR)$(LUA_LDIR)/$T/threat.lua
 
 clean:
 	$(RM) src/$(LIBNAME) $(OBJS)


### PR DESCRIPTION
The installed `*.lua` files do not need to be executable, just the shared library.