### PR TITLE
spec: fix for Lua5.5

### DIFF
--- a/spec/01-lxp_spec.lua
+++ b/spec/01-lxp_spec.lua
@@ -41,6 +41,7 @@ describe("lxp:", function()
 		assert(type(cbs) == "table", "expected arg #1 to be a table")
 		local t = {}
 		for k,v in pairs(cbs) do
+			local k, v = k, v -- loop variables are read-only in 5.5+, copy to locals
 			if type(k) == "number" then
 				assert(type(v) == "string", "array entries must have string values")
 				k = v

--- a/spec/01-lxp_spec.lua
+++ b/spec/01-lxp_spec.lua
@@ -41,7 +41,7 @@ describe("lxp:", function()
 		assert(type(cbs) == "table", "expected arg #1 to be a table")
 		local t = {}
 		for k,v in pairs(cbs) do
-			local k, v = k, v -- loop variables are read-only in 5.5+, copy to locals
+			local k = k
 			if type(k) == "number" then
 				assert(type(v) == "string", "array entries must have string values")
 				k = v


### PR DESCRIPTION
fix #42

> From https://www.lua.org/manual/5.5/manual.html#8.1
>
> The control variable in for loops is read only. If you need to change it,
> declare a local variable with the same name in the loop body.