### PR TITLE
Add Dependabot for GitHub Actions and pin workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot...
+# https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/auto-update-actions
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly
+    cooldown:  # https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html
+      default-days: 7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,12 +5,12 @@ on: [ push, workflow_dispatch ]
 jobs:
 
   affected:
-    uses: lunarmodules/.github/.github/workflows/list_affected_rockspecs.yml@main
+    uses: lunarmodules/.github/.github/workflows/list_affected_rockspecs.yml@5e21af2b298be5ad6677a4737114db239510d3ce # main
 
   build:
     needs: affected
     if: ${{ needs.affected.outputs.rockspecs }}
-    uses: lunarmodules/.github/.github/workflows/test_build_rock.yml@main
+    uses: lunarmodules/.github/.github/workflows/test_build_rock.yml@5e21af2b298be5ad6677a4737114db239510d3ce # main
     with:
       rockspecs: ${{ needs.affected.outputs.rockspecs }}
 
@@ -27,7 +27,7 @@ jobs:
         ( github.ref_name == 'master' || startsWith(github.ref, 'refs/tags/') ) &&
         needs.affected.outputs.rockspecs
       }}
-    uses: lunarmodules/.github/.github/workflows/upload_to_luarocks.yml@main
+    uses: lunarmodules/.github/.github/workflows/upload_to_luarocks.yml@5e21af2b298be5ad6677a4737114db239510d3ce # main
     with:
       rockspecs: ${{ needs.affected.outputs.rockspecs }}
     secrets:

--- a/.github/workflows/docs_lint.yml
+++ b/.github/workflows/docs_lint.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: anishathalye/proof-html@v1
+      - uses: anishathalye/proof-html@de0745a75f536af1360d37849a8a732413fad66b # v1
         with:
           directory: ./docs
           check_favicon: false

--- a/.github/workflows/docs_lint.yml
+++ b/.github/workflows/docs_lint.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - uses: anishathalye/proof-html@v1
         with:

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Luacheck
-        uses: lunarmodules/luacheck@v0
+        uses: lunarmodules/luacheck@2445a9dd3859655646bd6eb848459f2b46b4a3e3 # v0


### PR DESCRIPTION
This PR adds Dependabot support for GitHub Actions and pins workflow action references to commit SHAs.

Commits:
1. Add Dependabot config for GitHub Actions (modeled after terminal.lua)
2. Pin workflow actions to commit SHAs and include version/tag comments after each SHA so Dependabot can update both.